### PR TITLE
Updating build pipeline to build app.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 lib/
 node_modules/
 
+# Config Files
+src/app.json
+
 # Build Output
 dist/
 reports/

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ gulp protractor      # Execute e2e tests with Protractor
 gulp protractor:dist # Execute e2e tests with Protractor on build output
 ```
 
+Running and building with configuration
+
+```
+gulp --corpToken [CORP_TOKEN] --sl [SWIMLANE] --companyName [COMPANY_NAME]
+gulp serve --corpToken [CORP_TOKEN] --sl [SWIMLANE] --companyName [COMPANY_NAME]
+```
+
 ## Helpful Utilities
 
 * **[NPM-Check-Updates](https://github.com/tjunnone/npm-check-updates)** - checks for updates of node modules with CLI

--- a/build/build.js
+++ b/build/build.js
@@ -79,7 +79,7 @@ gulp.task('fonts', function () {
         .pipe(gulp.dest(path.join(conf.paths.dist, '/fonts/')));
 });
 
-gulp.task('other', function () {
+gulp.task('other', ['config:app'], function () {
     var fileFilter = $.filter(function (file) {
         return file.stat.isFile();
     });

--- a/build/build.js
+++ b/build/build.js
@@ -44,7 +44,7 @@ gulp.task('html', ['inject', 'partials'], function () {
         .pipe($.rev())
         .pipe(jsFilter)
         .pipe($.ngAnnotate())
-        .pipe($.uglify({ preserveComments: $.uglifySaveLicense })).on('error', conf.errorHandler('Uglify'))
+        .pipe($.uglify({preserveComments: $.uglifySaveLicense})).on('error', conf.errorHandler('Uglify'))
         .pipe(jsFilter.restore)
         .pipe(cssFilter)
         .pipe($.csso())
@@ -86,7 +86,7 @@ gulp.task('other', function () {
 
     return gulp.src([
         path.join(conf.paths.src, '/**/*'),
-        path.join('!' + conf.paths.src, '/**/*.{html,css,js,scss}')
+        path.join('!' + conf.paths.src, '/**/*.{html,css,js,scss,template}')
     ])
         .pipe(fileFilter)
         .pipe(gulp.dest(path.join(conf.paths.dist, '/')));

--- a/build/server.js
+++ b/build/server.js
@@ -46,7 +46,7 @@ browserSync.use(browserSyncSpa({
     selector: '[ng-app]'// Only needed for angular apps
 }));
 
-gulp.task('serve', ['watch'], function () {
+gulp.task('serve', ['watch', 'config:app'], function () {
     browserSyncInit([path.join(conf.paths.tmp, '/serve'), conf.paths.src]);
 });
 
@@ -54,7 +54,7 @@ gulp.task('serve:dist', ['build'], function () {
     browserSyncInit(conf.paths.dist);
 });
 
-gulp.task('serve:e2e', ['inject'], function () {
+gulp.task('serve:e2e', ['inject', 'config:app'], function () {
     browserSyncInit([conf.paths.tmp + '/serve', conf.paths.src], []);
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var exec = require('child_process').exec;
 var fs = require('fs');
 var argv = require('yargs').argv;
 var dateFormat = require('dateformat');
+var chalk = require('chalk');
 
 /**
  *  This will load all js or coffee files in the gulp directory
@@ -33,6 +34,30 @@ gulp.task('jenkins:build', function (done) {
 
 gulp.task('travis:build', function (done) {
     runSequence('clean', 'build', 'test:jenkins', done);
+});
+
+gulp.task('config:app', function () {
+    var appConfig = JSON.parse(fs.readFileSync('./src/app.json.template'));
+
+    if (argv.corp) {
+        appConfig.service.corpToken = argv.corp;
+    } else {
+        console.log(chalk.red('Argument for corpToken not found, output might not be setup correctly. Supply the corpToken via the --corp flag.'));
+    }
+
+    if (argv.sl) {
+        appConfig.service.swimlane = argv.sl;
+    } else {
+        console.log(chalk.red('Argument for swimlane not found, output might not be setup correctly. Supply the swimlane via the --sl flag.'));
+    }
+
+    if (argv.companyName) {
+        appConfig.companyName = argv.companyName;
+    } else {
+        console.log(chalk.red('Argument for companyName not found, output might not be setup correctly. Supply the companyName via the --companyName flag.'));
+    }
+
+    fs.writeFileSync('src/app.json', JSON.stringify(appConfig, null, 4));
 });
 
 gulp.task('version', function () {


### PR DESCRIPTION
Updating the build pipeline to parse the `app.json.template` and pump in the command line arguments for each property.

Will alert the user when a command line argument is missing, but won't fail the build.

Added documentation in the README.md to help guide users in the new process.