### PR TITLE
feature(templates): Adding GitHub Issue/PR Templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+INSERT SHORT DESCRIPTION EXPLAINING THE HIGH-LEVEL REASON FOR THE NEW ISSUE HERE.
+
+## Current behavior
+
+-
+
+## Expected behavior
+
+-
+
+## Steps to replicate behavior
+
+1.
+
+## Screenshots
+
+__Current__
+
+
+__Expected__
+

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+INSERT SHORT DESCRIPTION EXPLAINING THE HIGH-LEVEL REASON FOR THE NEW PULL REQUEST HERE.
+
+## Additions
+
+-
+
+## Removals
+
+-
+
+## Changes
+
+-
+
+## Testing
+
+-
+
+## Review
+
+- @user
+
+## Screenshots
+
+
+## Notes
+
+-
+
+## TODOs
+
+-
+
+## Checklist
+
+* [ ] Changes are limited to a single goal (no scope creep)
+* [ ] Code can be automatically merged (no conflicts)
+* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
+* [ ] Passes all existing automated tests
+* [ ] New functions include new tests
+* [ ] New functions are documented (with a description, list of inputs, and expected output)
+* [ ] Placeholder code is flagged
+* [ ] Visually tested in supported browsers and devices


### PR DESCRIPTION
Adding new Github templates for new issues/pull requests. Documented here: https://github.com/blog/2111-issue-and-pull-request-templates.

Pretty neat. This is a basic implementation. I am sure we will come up with something to use across all Bullhorn Open Source Projects.