### PR TITLE
Removed ES6 includes method.

### DIFF
--- a/src/app/detail/detail.controller.js
+++ b/src/app/detail/detail.controller.js
@@ -41,7 +41,7 @@ class JobDetailController {
         var alreadyAppliedJobs = sessionStorage.getItem(this.APPLIED_JOBS_KEY);
         if (alreadyAppliedJobs) {
             var alreadyAppliedJobsArray = JSON.parse(alreadyAppliedJobs);
-            this.alreadyApplied = alreadyAppliedJobsArray.includes(this.job.id);
+            this.alreadyApplied = (alreadyAppliedJobsArray.indexOf(this.job.id) !== -1);
         }
     }
 


### PR DESCRIPTION
In lieu of reviewing the documentation and getting determining how to get our polyfills for ES6 to work properly, since we only use `includes` in one place, I rolled that method back to a legacy `indexOf` method.

## Changes

- Reverted `includes` to `indexOf`

## Review

- @jgodi 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices

