### PR TITLE
Min Upload Size

### DIFF
--- a/src/app.json.template
+++ b/src/app.json.template
@@ -15,7 +15,7 @@
         "en-US",
         "fr-FR"
     ],
-    "minUploadSize": 30720,
+    "minUploadSize": 4096,
     "maxRelatedJobs": 5,
     "maxUploadSize": 5242880,
     "service": {

--- a/src/app/modal/modal.controller.js
+++ b/src/app/modal/modal.controller.js
@@ -85,6 +85,11 @@ class CareerPortalModalController {
             this.updateUploadClass(false);
             this.isSubmitting = false;
             return false;
+        } else if (file.size < this.configuration.minUploadSize) {
+            this.resumeUploadErrorMessage = this.$filter('i18n')('modal.resumeToSmall') + ' (' + this.$filter('i18n')('modal.minLabel') + ': ' + this.configuration.minUploadSize / 1024 + 'KB)';
+            this.updateUploadClass(false);
+            this.isSubmitting = false;
+            return false;
         }
 
         this.resumeUploadErrorMessage = null;

--- a/test/unit/controllers/modal.controller.spec.js
+++ b/test/unit/controllers/modal.controller.spec.js
@@ -9,7 +9,9 @@ describe('Controller: CareerPortalModalController', () => {
                 someUrl: '/dummyValue',
                 service: {corpToken: 1, port: 1, swimlane: 1},
                 integrations: {linkedin: {clientId: ''}},
-                acceptedResumeTypes: ['html', 'text', 'txt']
+                acceptedResumeTypes: ['html', 'text', 'txt'],
+                minUploadSize: 4096,
+                maxUploadSize: 5242880
             });
         });
     });
@@ -84,6 +86,41 @@ describe('Controller: CareerPortalModalController', () => {
     describe('Function: validateResume(file)', () => {
         it('should be defined.', () => {
             expect(vm.validateResume).toBeDefined();
+        });
+
+        beforeEach(() => {
+            spyOn(vm, '$filter').and.callFake(function () {
+                return function (string) {
+                    var localization = {
+                        resumeToBig: 'Too Big',
+                        resumeToSmall: 'Too Small',
+                        maxLabel: 'max',
+                        minLabel: 'min',
+                        resumeInvalidFormat: 'INVALID'
+                    };
+                    string = string.replace('modal.', '');
+                    return localization[string];
+                };
+            });
+        });
+
+        it('should return false and set the error message for an invalid format', () => {
+            var validateResult = vm.validateResume({name: 'Test.pdf', size: 10});
+            expect(validateResult).toBe(false);
+            expect(vm.isSubmitting).toBe(false);
+            expect(vm.resumeUploadErrorMessage).toEqual('PDF INVALID');
+        });
+        it('should return false and set the error message for a file that is too big', () => {
+            var validateResult = vm.validateResume({name: 'Test.txt', size: 6000000});
+            expect(validateResult).toBe(false);
+            expect(vm.isSubmitting).toBe(false);
+            expect(vm.resumeUploadErrorMessage).toEqual('Too Big (max: 5MB)');
+        });
+        it('should return false and set the error message for a file that is too small', () => {
+            var validateResult = vm.validateResume({name: 'Test.txt', size: 50});
+            expect(validateResult).toBe(false);
+            expect(vm.isSubmitting).toBe(false);
+            expect(vm.resumeUploadErrorMessage).toEqual('Too Small (min: 4KB)');
         });
     });
 


### PR DESCRIPTION
We were not enforcing the `minUploadSize` when uploading a resume.

## Additions

- Added a check in the `validateResume` for the `minUploadSize`.

## Removals

- None

## Changes

- None

## Testing

- Added unit tests for the `modal`'s `validateResume` method for `minUploadSize`, `maxUploadSize`, and `invalidFormat`.

## Review

- @krsween 
- @TheReal 

## Screenshots
![Screenshot](http://s28.postimg.org/msdjgyia5/Screenshot_2016_04_11_08_47_01.png)
-

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices