### PR TITLE
Enable Galaxy coverage for project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ branches:
   only:
     - master
 
+cache:
+  directories:
+    - node_modules
+
 before_script:
   - npm install gulp -g
   - npm install bower -g
@@ -30,3 +34,4 @@ script:
 after_success:
   - npm install codeclimate-test-reporter -g
   - codeclimate-test-reporter < reports/lcov/lcov.info
+  - test $TRAVIS_BRANCH = "master" && npm run galaxy -- $FIREBASE_URL $SLACK_WEB_HOOK $SLACK_CHANNEL

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "CareerPortal",
   "version": "1.6.0",
+  "scripts": {
+    "loc": "sloc src/ --format json > ./reports/sloc.json",
+    "pregalaxy": "npm run lint:save && npm run loc",
+    "galaxy": "galaxy analyze"
+  },
   "devDependencies": {
     "babel-core": "~5.8.23",
     "babel-loader": "~5.3.2",
@@ -9,6 +14,7 @@
     "chalk": "~1.1.1",
     "dateformat": "^1.0.11",
     "del": "~2.0.1",
+    "galaxy-parser": "^1.0.4",
     "gulp": "~3.9.0",
     "gulp-angular-templatecache": "~1.7.0",
     "gulp-autoprefixer": "~3.0.1",
@@ -60,5 +66,15 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/bullhorn/career-portal.git"
+  },
+  "galaxy": {
+    "display": "Career Portal",
+    "type": "javascript",
+    "goal": 80,
+    "threshold": 0.1,
+    "locations": {
+      "sloc": "/reports/sloc.json",
+      "lcov": "/reports/lcov/lcov.info"
+    }
   }
 }


### PR DESCRIPTION
Add Galaxy code coverage reporting to the Career Portal project

## Additions

- Galaxy configuration in package.json
- Galaxy invocation after successful Travis build

## Removals

## Testing

## Review

- @jgodi 

## Screenshots

## Notes

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices

