### PR TITLE
fix(print): Fixes print media queries, closes #87

### DIFF
--- a/src/app/print.scss
+++ b/src/app/print.scss
@@ -1,52 +1,68 @@
 @media print {
     html {
-        overflow: visible;
+        overflow: visible !important;
+        height: initial;
 
         > body {
-            overflow: visible;
+            overflow: visible !important;
+            height: initial;
 
-            &.overview-open {
-                overflow: visible;
+            section.overview-open {
+                overflow: visible !important;
 
-                > section.portal-app {
-                    overflow: visible;
+                > section.portal {
+                    overflow: visible !important;
 
-                    > aside.sidebar {
+                    aside.sidebar {
                         display: none;
                     }
 
-                    > section.main {
-                        overflow: visible;
+                    section.main {
+                        overflow: visible !important;
 
                         > header {
-                            button[name="filters-menu"], button[name="over-arrow-back"] {
+                            button[name="filters-menu"],
+                            button[name="over-arrow-back"] {
                                 display: none;
                             }
                         }
+                    }
+                }
+            }
 
-                        > section.fade {
-                            overflow: visible;
+            section.fade {
+                overflow: visible !important;
+                height: auto;
 
-                            > section.job-detail {
-                                overflow: visible;
-                                flex-direction: column;
+                > section.job-detail {
+                    overflow: visible !important;
+                    flex-direction: column;
 
-                                > div.description {
-                                    order: 2;
-                                    .job-actions {
-                                        display: none;
-                                    }
-                                }
-
-                                > div.apply {
-                                    width: 100%;
-                                    button.apply, hr, .related-jobs, .category-filter {
-                                        display: none;
-                                    }
-                                }
-                            }
+                    > div.description {
+                        order: 2;
+                        overflow: visible !important;
+                        //page-break-before: always;
+                        .job-actions {
+                            display: none;
                         }
                     }
+                }
+            }
+
+            button.bhi-arrow-back {
+                display: none;
+            }
+
+            div.apply {
+                width: 100%;
+
+                .apply,
+                .break,
+                .btn-li-lg,
+                .category-filter,
+                .related-jobs,
+                hr {
+                    display: none !important;
                 }
             }
         }


### PR DESCRIPTION
From #87 : 

> When clicking on the "Print" button to print preview and print on a job posting that has a tons of job description paragraphs, the vertical scrollbar appears on the print preview and doesn't show all of the paragraphs.

## Updates

- Fixes improper SCSS nesting
- Removes fixed `height` on body when in `@print` media query

## Review

- @jgodi , @krsween 

## Screenshots

<img width="987" alt="screen shot 2016-08-30 at 2 03 16 pm" src="https://cloud.githubusercontent.com/assets/5579814/18100877/96c9bb64-6eba-11e6-853e-16e0ef6f9227.png">

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices

