### PR TITLE
Fix for smaller resolution screens - part 2

### DIFF
--- a/src/app/modal/modal.scss
+++ b/src/app/modal/modal.scss
@@ -29,6 +29,15 @@
                 max-width: 500px !important;
             }
         }
+        
+        @media screen and (max-height: 700px) and (min-width: 992px){
+            margin: 0px auto;
+            -ms-transform: scale(.85); /* IE 9 */
+            -webkit-transform: scale(.85); /* Safari */
+            transform: scale(.85); /* Firefox, Opera, Chrome */
+            
+        }
+
 
         &.success {
             height: auto;


### PR DESCRIPTION
I have revisited #41 and have determined that even with the removal of the Apply with LinkedIn button that the submit and cancel buttons are still cut out preventing people from applying. This is mostly affecting older apple machines and lower end machines that use Internet explorer on a 1366 x 768 display.    

## Additions

- Added a media query for lower resolution screens still in a wide aspect ratio (ex. 16:9 or 1366x768)  

## Removals

- N/A

## Testing

- I have tested this on the big 4 browsers: Internet Explorer, Microsoft Edge, Mozilla Firefox, and Google Chrome.  
- I made sure to test to see if this affects the tablet or phone logic.  It is unaffected. 


## GIF of the logic

![](https://thumbs.gfycat.com/AlarmedDelayedEmperorshrimp-size_restricted.gif)

## Notes

- This change is based on the fact that the minimum supported desktop resolution is 1280 x 800.  I am attempting to bring that resolution down to 1280 x 720.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices

A fix for smaller resolution screens