### PR TITLE
Fix for IE slideout bug

### DIFF
--- a/src/app/sidebar/sidebar.scss
+++ b/src/app/sidebar/sidebar.scss
@@ -9,6 +9,7 @@ aside {
     color: $white;
     flex-direction: column;
     transition: all 0.2s ease-in-out;
+    z-index: 125;
 
     @include tablet() {
         width: $sidebar-width;


### PR DESCRIPTION
Fix for IE slideout bug. This fixes #103

## Additions / Removals

- just added a z index so the sidebar is on top of the mask.

## Testing

- tested in Chrome, IE, Firefox, and on Android in Chrome.

## Screenshots


## Notes

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
