### PR TITLE
refactor job searching so it only has to make one search call

### DIFF
--- a/src/app/services/search.service.js
+++ b/src/app/services/search.service.js
@@ -312,19 +312,6 @@ class SearchService {
         });
     }
 
-    recursiveQueryForIDs(callbackIfNoMore, start, count, errorCallback) {
-        errorCallback = errorCallback || (() => {
-            });
-
-        this
-            .$http({
-                method: 'GET',
-                url: this._queryUrl + this.requestParams.assembleForQueryForIDs(start, count)
-            })
-            .success(callbackIfNoMore)
-            .error(errorCallback);
-    }
-
     recursiveSearchForJobs(callbackIfNoMore, start, count, errorCallback) {
         errorCallback = errorCallback || (() => {
             });

--- a/src/app/services/search.service.js
+++ b/src/app/services/search.service.js
@@ -209,6 +209,9 @@ class SearchService {
                 assembleForQueryForIDs: (start, count) => {
                     return '?where=' + this.requestParams.query(false) + '&fields=' + SearchService._fields + '&count=' + count + '&orderBy=' + SearchService._sort + '&start=' + start;
                 },
+                assembleForSearchForJobs: (start, count) => {
+                    return '?query=' + this.requestParams.query(true) + '&fields=' + SearchService._fields + '&count=' + count + '&sort=' + SearchService._sort + '&start=' + start;
+                },
                 assembleForGroupByWhereIDs: (fields, orderByFields, start, count, jobs) => {
                     return '?where=' + this.requestParams.whereIDs(jobs, false) + '&groupBy=' + fields + '&fields=' + fields + ',count(id)&count=' + count + '&orderBy=+' + orderByFields + ',-count.id&start=' + start;
                 },
@@ -322,6 +325,19 @@ class SearchService {
             .error(errorCallback);
     }
 
+    recursiveSearchForJobs(callbackIfNoMore, start, count, errorCallback) {
+        errorCallback = errorCallback || (() => {
+            });
+
+        this
+            .$http({
+                method: 'GET',
+                url: this._searchUrl + this.requestParams.assembleForSearchForJobs(start, count)
+            })
+            .success(callbackIfNoMore)
+            .error(errorCallback);
+    }
+
     findJobs() {
         if (this.searchParams.reloadAllData) {
             this.helper.emptyCurrentDataList();
@@ -350,32 +366,26 @@ class SearchService {
 
         let callbackIfNoMore = (data) => {
             if (data.data.length) {
-                controller.searchWhereIDs(data.data, (jobs) => {
-                    for (let i = 0; i < data.data.length; i++) {
-                        for (let i2 = 0; i2 < jobs.length; i2++) {
-                            if (jobs[i2].id === data.data[i].id) {
-                                allJobs.push(data.data[i]);
-                            }
-                        }
-                    }
+                for (let i = 0; i < data.data.length; i++) {
+                    allJobs.push(data.data[i]);
+                }
 
-                    if (data.count < count) {
-                        doneFinding(allJobs);
-                    } else if (allJobs.length >= controller.requestParams.count()) {
-                        this.helper.hasMore = true;
-                        doneFinding(allJobs);
-                    } else {
-                        controller.helper.updateStart(count);
-                        start = controller.requestParams.start();
-                        controller.recursiveQueryForIDs(callbackIfNoMore, start, count);
-                    }
-                });
+                if (data.count < count) {
+                    doneFinding(allJobs);
+                } else if (allJobs.length >= controller.requestParams.count()) {
+                    this.helper.hasMore = true;
+                    doneFinding(allJobs);
+                } else {
+                    controller.helper.updateStart(count);
+                    start = controller.requestParams.start();
+                    controller.recursiveSearchForJobs(callbackIfNoMore, start, count);
+                }
             } else {
                 doneFinding(allJobs);
             }
         };
 
-        this.recursiveQueryForIDs(callbackIfNoMore, start, count);
+        this.recursiveSearchForJobs(callbackIfNoMore, start, count);
     }
 
     loadJobData(jobID, callback, errorCallback) {

--- a/test/unit/controllers/modal.controller.spec.js
+++ b/test/unit/controllers/modal.controller.spec.js
@@ -1,5 +1,5 @@
 /* global describe, beforeEach, expect, it, spyOn */
-fdescribe('Controller: CareerPortalModalController', () => {
+describe('Controller: CareerPortalModalController', () => {
     let vm,
         $controller;
 

--- a/test/unit/services/search.service.spec.js
+++ b/test/unit/services/search.service.spec.js
@@ -72,6 +72,12 @@ describe('Service: SearchService', () => {
         });
     });
 
+    describe('Function: recursiveSearchForJobs()', () => {
+        it('should be defined.', () => {
+            expect(SearchService.recursiveSearchForJobs).toBeDefined();
+        });
+    });
+
     describe('Function: getCountBy()', () => {
         it('should be defined.', () => {
             expect(SearchService.getCountBy).toBeDefined();

--- a/test/unit/services/search.service.spec.js
+++ b/test/unit/services/search.service.spec.js
@@ -90,12 +90,6 @@ describe('Service: SearchService', () => {
         });
     });
 
-    describe('Function: recursiveQueryForIDs()', () => {
-        it('should be defined.', () => {
-            expect(SearchService.recursiveQueryForIDs).toBeDefined();
-        });
-    });
-
     describe('Function: findJobs()', () => {
         it('should be defined.', () => {
             expect(SearchService.findJobs).toBeDefined();


### PR DESCRIPTION
Refactored job searching so that it only makes a single call to search/JobOrder instead of querying JobBoardPost and then search/JobOrder.

## Additions / Removals

- Removed the double recursive searching for JobBoardPost/JobOrder and made a single recursive search for JobOrder only.

## Testing

- Tested against BHNext test corp after reindexing jobs
- Published, Republished, Unpublished jobs from the ATS and verified they were updated in the career portal
- Tested keyword, location, and category searching
- Verified new ATS JobOrder index field dateLastPublished worked correctly in order to properly sort jobs in the career portal
- Verified Load more... would load more jobs until there were no more jobs left to load

## Screenshots


## Notes

- A new field (dateLastPublished) was added to the JobOrder index in 2017.7.  This code leverages the new field when searching (specifically sorting jobs by -dateLastPublished), so clients that want to use this will require a JobOrder reindex or they will see some strange results when searching jobs in the Career Portal.


## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
