### PR TITLE
Typo update and update hyperlink

### DIFF
--- a/src/app/detail/detail.html
+++ b/src/app/detail/detail.html
@@ -13,7 +13,7 @@
             {{::detail.job.address.city}}<span data-ng-if="::(detail.job.address.city && detail.job.address.state)">,&nbsp;</span>{{::detail.job.address.state}}
         </span>
         <!-- SEPARATOR -->
-        <span class="card-separator" data-ng-show="::((detail.job.address.city || detail.job.address.state) && detail.job.employmentType)">|</span>
+        <span class="card-separator" data-ng-show="::((detail.job.address.city || detail.job.address.state) && detail.job.employmentType)"> | </span>
         <!-- JOB TYPE -->
         <span class="card-type">{{::detail.job.employmentType}}</span>
         <!-- APPLY WITH LINKED IN || EMAIL JOB -->

--- a/src/app/services/share.service.js
+++ b/src/app/services/share.service.js
@@ -27,7 +27,7 @@ class ShareService {
                 additionalEmailInfo: job => '?subject=' + encodeURIComponent(job.title) + '&body=' + this.description(job, window.location.href) + this.additionalEmailInfo(job),
                 facebook: () => '?display=popup&app_id=' + this.config.keys.facebook + '&href=' + encodeURIComponent(window.location.href) + '&redirect_uri=' + encodeURIComponent('https://www.facebook.com/'),
                 twitter: job => '?text=' + encodeURIComponent(this.description(job)) + '&url=' + encodeURIComponent(window.location.href),
-                linkedin: job => '?mini=true&source=Bullhorn%20Carrer%20Portal&title=' + encodeURIComponent(this.description(job)) + '&url=' + encodeURIComponent(window.location.href),
+                linkedin: job => '?mini=true&source=Bullhorn%20Career%20Portal&title=' + encodeURIComponent(this.description(job)) + '&url=' + encodeURIComponent(window.location.href),
                 email: job => '?subject=' + encodeURIComponent(job.title) + '&body=' + this.description(job, window.location.href)
             });
     }

--- a/src/app/sidebar/sidebar.html
+++ b/src/app/sidebar/sidebar.html
@@ -77,7 +77,9 @@
 
         <section class="credits">
             <span class="powered-by">{{'sidebar.poweredByText' | i18n}}</span>
-            <img class="bullhorn" src="assets/images/logo.svg"></img>
+            <a target="_blank" href="http://www.bullhorn.com/">
+                <img class="bullhorn" src="assets/images/logo.svg"></img>
+            </a>
         </section>
 
         <button type="button" class="bhi-arrow-left" name="back-arrow" data-ng-click="sidebar.goBack();"></button>


### PR DESCRIPTION
This fixes #155 and fixes #156.  

This is for several small fixes/changes that has persisted on the portal.

## Additions / Removals

- I have updated the typo with the LinkedIn Source when sharing a Job to LinkedIn. 
- I added a hyperlink to http://www.bullhorn.com/ when you click the bull
- I have updated the spacing between the city and category

## Testing

- I have ran the portal locally and checked in the 3 major browsers (IE, Firefox, and Chrome)

## Screenshots
![image](https://user-images.githubusercontent.com/4327754/29033368-6e818508-7b5a-11e7-8193-cbd2bd6b0533.png)


## Notes

- N/A

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices

> 

> 