### PR TITLE
Adjust search logic to correct issue #173

### DIFF
--- a/src/app/services/search.service.js
+++ b/src/app/services/search.service.js
@@ -161,7 +161,7 @@ class SearchService {
                     return '';
                 },
                 query: (isSearch, additionalQuery, fields) => {
-                    let query = `(isOpen${isSearch ? ':1' : '=true'})`;
+                    let query = `(isOpen${isSearch ? ':1' : '=true'} AND isDeleted${isSearch ? ':0' : '=false'})`;
 
                     if (additionalQuery) {
                         query += ` AND (${additionalQuery})`;


### PR DESCRIPTION
Adding logic to the portal's search service to prevent jobs that are both Open and Deleted from displaying in the list view.

## Additions / Removals

-

## Testing

-Tested on Chrome. Functionality is essentially the same, but jobs that are both Open and Deleted no longer show up.

## Screenshots


## Notes

-

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
