### PR TITLE
trim whitespace from location filter. fixes #184

### DIFF
--- a/src/app/sidebar/sidebar.controller.js
+++ b/src/app/sidebar/sidebar.controller.js
@@ -168,7 +168,7 @@ class CareerPortalSidebarController {
     }
 
     addOrRemoveLocation(location) {
-        let key = location.address.city + '|' + location.address.state;
+        let key = location.address.city.trim() + '|' + location.address.state.trim();
         if (!this.hasLocationFilter(location)) {
             this.SearchService.searchParams.location.push(key);
         } else {
@@ -190,7 +190,7 @@ class CareerPortalSidebarController {
     }
 
     hasLocationFilter(location) {
-        let key = location.address.city + '|' + location.address.state;
+        let key = location.address.city.trim() + '|' + location.address.state.trim();
         return this.SearchService.searchParams.location.indexOf(key) !== -1;
     }
 


### PR DESCRIPTION
#184 brought up an issue with searching if there is a trailing or leading space in front of the location.  This addresses that. 

## Additions / Removals

- Added trim to location filter key so you are able to filter where there is an errant trailing or leading space.  

## Testing

- Tested in the 4 major browsers

## Screenshots
N/A

## Notes

-

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
