### PR TITLE
Remove google fonts and use package fonts

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "bullhorn-icons": "~1.9.0",
     "moment": "~2.15.1",
     "normalize.css": "~5.0.0",
-    "roboto-fontface": "~0.5.0",
+    "roboto-fontface": "~0.4.5",
     "angular-ui-router": "^0.3.1",
     "ng-fastclick": "^1.0.2",
     "ng-file-upload": "^12.2.12",

--- a/src/index.html
+++ b/src/index.html
@@ -6,8 +6,6 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
         <title>Career Portal</title>
-        <!-- default font -->
-        <link href='//fonts.googleapis.com/css?family=Roboto:400,700,500' rel='stylesheet' type='text/css'>
 
         <!-- build:css({.tmp/serve,src}) styles/vendor.css -->
         <!-- bower:css -->


### PR DESCRIPTION
Currently in the CP the portal flashes whenever loading fonts since it just falls back to Google Fonts.  This is because the current roboto version updated the path location which made things act a bit wonky.  This pull request fixes this temporarily by locking to a previous roboto version until the build process is updated

## Additions / Removals

- adding fonts into the repo instead of using the package.  

## Testing

- 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
