### PR TITLE
add required asterisks to EEOC form

### DIFF
--- a/src/app/modal/modal.html
+++ b/src/app/modal/modal.html
@@ -145,7 +145,10 @@
                             </div>
                             <div class="form-field">
                                 <div class="input eeoc">
-                                    <label for="eeoc-gender">{{ 'eeoc.genderLabel' | i18n }}</label>
+                                    <label for="eeoc-gender">
+                                            <span class="required">*</span>
+                                            {{ 'eeoc.genderLabel' | i18n }}
+                                        </label>
                                     <select id="eeoc-gender" data-ng-model="modal.ApplyService.form.gender" data-ng-required="modal.EeocService.isGenderRaceEthnicityEnabled()">
                                         <option value="M">{{ 'eeoc.genderMale' | i18n }}</option>
                                         <option value="F">{{ 'eeoc.genderFemale' | i18n }}</option>
@@ -156,6 +159,7 @@
                             <div class="form-field">
                                 <div class="input eeoc">
                                     <label for="eeoc-ethnicity">
+                                        <span class="required">*</span>
                                         {{ 'eeoc.raceEthnicityLabel' | i18n }}
                                         <a data-ng-click="modal.showTooltip(2)"><i class="bhi-question"></i></a>
                                     </label>
@@ -196,7 +200,10 @@
                             </div>
                             <div class="form-field">
                                 <div class="input eeoc">
-                                    <label for="eeoc-veteran">{{ 'eeoc.veteranLabel' | i18n }}</label>
+                                    <label for="eeoc-veteran">
+                                        <span class="required">*</span>
+                                        {{ 'eeoc.veteranLabel' | i18n }}
+                                    </label>
                                     <select id="eeoc-veteran" data-ng-model="modal.ApplyService.form.veteran" data-ng-required="modal.EeocService.isVeteranEnabled()">
                                         <option value="P">{{ 'eeoc.veteranP' | i18n }}</option>
                                         <option value="V">{{ 'eeoc.veteranV' | i18n }}</option>
@@ -217,7 +224,10 @@
                             </div>
                             <div class="form-field">
                                 <div class="input eeoc">
-                                    <label for="eeoc-disability">{{ 'eeoc.disabilityLabel' | i18n }}</label>
+                                    <label for="eeoc-disability">
+                                        <span class="required">*</span>
+                                        {{ 'eeoc.disabilityLabel' | i18n }}
+                                    </label>
                                     <select id="eeoc-disability" data-ng-model="modal.ApplyService.form.disability" data-ng-required="modal.EeocService.isDisabilityEnabled()">
                                         <option value="Y">{{ 'eeoc.disabilityY' | i18n }}</option>
                                         <option value="N">{{ 'eeoc.disabilityN' | i18n }}</option>

--- a/src/app/modal/modal.scss
+++ b/src/app/modal/modal.scss
@@ -217,6 +217,10 @@
                                     width: 100%;
                                     font-size: 1.1em;
                                     color: rgb(121, 124, 126);
+                                    > .required {
+                                        color: $error;
+                                        font-size: 1.2em;
+                                    }
                                 }
 
                                 select {


### PR DESCRIPTION
I added required asterisks to EEOC form to fix #198 

## Additions / Removals

- added the red asterisks to the apply modal to eeoc fields

## Testing

- tested in mobile and on desktop

## Screenshots
![image](https://user-images.githubusercontent.com/4327754/40216177-a942fd66-5a2a-11e8-8ef5-5cef0c39010f.png)


## Notes

-

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
