### PR TITLE
add option for restricting the portal jobs based on custom criteria

### DIFF
--- a/src/app.json.template
+++ b/src/app.json.template
@@ -29,7 +29,7 @@
             "clientId": "[ CLIENTID HERE ]"
         }
     },
-    "filter": {
+    "criteria": {
         "field": "[ FILTER FIELD HERE]",
         "values": [
             "[FILTER VALUE HERE]"

--- a/src/app.json.template
+++ b/src/app.json.template
@@ -29,6 +29,12 @@
             "clientId": "[ CLIENTID HERE ]"
         }
     },
+    "filter": {
+        "field": "[ FILTER FIELD HERE]",
+        "values": [
+            "[FILTER VALUE HERE]"
+        ]
+    },
     "defaultGridState": "list-view",
     "eeoc": {
         "genderRaceEthnicity": false,

--- a/src/app/services/search.service.js
+++ b/src/app/services/search.service.js
@@ -161,7 +161,7 @@ class SearchService {
                     return '';
                 },
                 query: (isSearch, additionalQuery, fields) => {
-                    let query = `(isOpen${isSearch ? ':1' : '=true'} AND isDeleted${isSearch ? ':0' : '=false'})${this.configFilter(isSearch)}`;
+                    let query = `(isOpen${isSearch ? ':1' : '=true'} AND isDeleted${isSearch ? ':0' : '=false'})${this.jobCriteria(isSearch)}`;
 
                     if (additionalQuery) {
                         query += ` AND (${additionalQuery})`;
@@ -412,9 +412,9 @@ class SearchService {
         return deferred.promise;
     }
 
-    configFilter(isSearch) {
-        let field = this.configuration.filter.field;
-        let values = this.configuration.filter.values;
+    jobCriteria(isSearch) {
+        let field = this.configuration.criteria.field;
+        let values = this.configuration.criteria.values;
         let query = '';
         let delimiter = isSearch ? '"' : '\'';
         let equals = isSearch ? ':' : '=';

--- a/src/app/services/search.service.js
+++ b/src/app/services/search.service.js
@@ -161,7 +161,7 @@ class SearchService {
                     return '';
                 },
                 query: (isSearch, additionalQuery, fields) => {
-                    let query = `(isOpen${isSearch ? ':1' : '=true'} AND isDeleted${isSearch ? ':0' : '=false'})`;
+                    let query = `(isOpen${isSearch ? ':1' : '=true'} AND isDeleted${isSearch ? ':0' : '=false'})${this.configFilter(isSearch)}`;
 
                     if (additionalQuery) {
                         query += ` AND (${additionalQuery})`;
@@ -410,6 +410,28 @@ class SearchService {
         });
 
         return deferred.promise;
+    }
+
+    configFilter(isSearch) {
+        let field = this.configuration.filter.field;
+        let values = this.configuration.filter.values;
+        let query = '';
+        let delimiter = isSearch ? '"' : '\'';
+        let equals = isSearch ? ':' : '=';
+
+
+        if (field && values.length > 0 && field !== '[ FILTER FIELD HERE ]' && values[0] !== '[ FILTER VALUE HERE ]') {
+            for (let i = 0; i < values.length; i++) {
+                if (i > 0) {
+                    query += ` OR `;
+                } else {
+                    query += ' AND (';
+                }
+                query += `${field}${equals}${delimiter}${values[i]}${delimiter}`;
+            }
+            query += ')';
+        }
+        return query;
     }
 }
 


### PR DESCRIPTION
I added options for restricting portal jobs for custom criteria that relates to #194 #211 and more

## Additions / Removals

- added additional options to the `app.json` file for filtering

## Testing

- tested in all 3 major browsers, tested with 1 values, multiple values, and no values

## Screenshots
 difficult to illustrate in a screenshot

## Notes

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
