### PR TITLE
also decode accented characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "pregalaxy": "npm run loc",
     "galaxy": "galaxy analyze"
   },
-  "dependencies": {},
+  "dependencies": {
+    "he": "^1.1.1"
+  },
   "devDependencies": {
     "babel-core": "^6.25.0",
     "babel-loader": "7.1.1",
@@ -38,6 +40,7 @@
     "gulp-uglify": "~3.0.0",
     "gulp-useref": "~3.1.2",
     "gulp-util": "~3.0.7",
+    "he": "^1.1.1",
     "http-proxy-middleware": "~0.17.4",
     "jscs": "^3.0.7",
     "jscs-loader": "^0.3.0",

--- a/src/app/filters/striphtml.filter.js
+++ b/src/app/filters/striphtml.filter.js
@@ -1,3 +1,5 @@
+var he = require('he');
+
 class StripHtml {
     constructor() {
         return function (input) {
@@ -21,26 +23,7 @@ class StripHtml {
                             }
                             /* jshint +W073 */
                         } else {
-                            switch (entity) {
-                                case 'quot':
-                                    ch = String.fromCharCode(0x0022);
-                                    break;
-                                case 'amp':
-                                    ch = String.fromCharCode(0x0026);
-                                    break;
-                                case 'lt':
-                                    ch = String.fromCharCode(0x003c);
-                                    break;
-                                case 'gt':
-                                    ch = String.fromCharCode(0x003e);
-                                    break;
-                                case 'nbsp':
-                                    ch = String.fromCharCode(0x00a0);
-                                    break;
-                                default:
-                                    ch = '';
-                                    break;
-                            }
+                            ch = he.decode('&' + entity + ';');
                         }
                         i = semicolonIndex;
                     }


### PR DESCRIPTION
Accented characters are being stripped out of the Job Description preview on the list view by the stripHtml filter. These changes should prevent them from being completely removed, and will decode them into Unicode format.

## Additions / Removals

-Add the he.decode dependency

## Testing

-Works in Chrome, Firefox and IE

## Screenshots
Previous Version:
![before_decode](https://user-images.githubusercontent.com/21197268/43777482-8e6ff236-9a18-11e8-80ab-c9e46c279df7.jpg)

After implementing Decode:
![after_decode](https://user-images.githubusercontent.com/21197268/43777487-9108687a-9a18-11e8-9d30-81a9847c434a.jpg)


## Notes

the he library should take care of the manual decoding portion of the stripHtml filter as well as these accented characters.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
