### PR TITLE
fix job sharing with ampersands and other special characters in email sending

### DIFF
--- a/src/app/services/share.service.js
+++ b/src/app/services/share.service.js
@@ -57,9 +57,9 @@ class ShareService {
 
     description(job, url) {
         if (url) {
-            return 'Check out this ' + job.title + ' job: ' + encodeURIComponent(url);
+            return 'Check out this ' + encodeURIComponent(job.title) + ' job: ' + encodeURIComponent(url);
         }
-        return 'Check out this ' + job.title + ' job!';
+        return 'Check out this ' + encodeURIComponent(job.title) + ' job!';
     }
 
     emailLink(job) {


### PR DESCRIPTION
Fix sharing when an ampersand is in the job title. fixes #236 

## Additions / Removals

- add additional uses of `encodeURIComponent`

## Testing

-


* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
