### PR TITLE
Fix jobInfoChips display issue on mobile devices

### DIFF
--- a/src/app/job-list/job-list.component.scss
+++ b/src/app/job-list/job-list.component.scss
@@ -92,7 +92,7 @@ novo-list {
     div.job-card{
       margin: 12px 15px;
       novo-list-item {
-        flex-direction: column;
+        flex-direction: inherit;
         item-header-end {
           display: flex;
           .mid-card {


### PR DESCRIPTION
On mobile devices currently, the jobInfoChips are overlapping the Job Title, this change resolves this issue. This PR should resolve Issue [#468](https://github.com/bullhorn/career-portal/issues/468) for Mobile users. I wasn't able to repro the issue in a Desktop environment.

## Additions / Removals

Nothing was added or removed, just amended one of the CSS values.

## Testing

Tested on Chrome on Android and using Dev Tools Mobile View on Chrome Desktop.

## Screenshots
![image](https://user-images.githubusercontent.com/47064656/166975542-c84b8d71-47e6-45e8-a292-720703f935dc.png)
![image](https://user-images.githubusercontent.com/47064656/166975557-e65331e0-28fb-413f-aaca-98b60968fc2f.png)


## Notes

This flex-direction value can also be defined as 'row' or potentially even be removed entirely since it appears to have no negative effect when removed (see screenshots)? It also has no effect (obviously) on the Desktop site since it is a mobile-only value.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
