### PR TITLE
Fix total count of filter options for issue #525

### DIFF
--- a/src/app/services/search/search.service.ts
+++ b/src/app/services/search/search.service.ts
@@ -3,11 +3,11 @@ import { HttpClient } from '@angular/common/http';
 import { SettingsService } from '../settings/settings.service';
 import { Observable, of } from 'rxjs';
 import { IServiceSettings } from '../../typings/settings';
-import { concatMap, map } from 'rxjs/operators';
+import { concatMap } from 'rxjs/operators';
 
 @Injectable()
 export class SearchService {
-  
+
   public constructor(private http: HttpClient, public settings: SettingsService) {  }
 
   get baseUrl(): string {
@@ -67,7 +67,7 @@ export class SearchService {
         };
 
         // Start fetching more records recursively
-        return fetchMoreRecords(currentCount).pipe(map(() => records));
+        return fetchMoreRecords(currentCount);
       }),
     );
   }

--- a/src/app/services/search/search.service.ts
+++ b/src/app/services/search/search.service.ts
@@ -7,12 +7,13 @@ import { concatMap, map } from 'rxjs/operators';
 
 @Injectable()
 export class SearchService {
-  public constructor(private http: HttpClient, public settings: SettingsService) {}
+  
+  public constructor(private http: HttpClient, public settings: SettingsService) {  }
 
   get baseUrl(): string {
     let service: IServiceSettings = SettingsService.settings?.service;
     let port: number = service?.port ? service.port : 443;
-    let scheme: string = `http${port === 443 ? 's' : ''}`;
+    let scheme: string = `http${ port === 443  ? 's' : '' }`;
 
     return `${scheme}://public-rest${service?.swimlane}.bullhornstaffing.com:${port}/rest-services/${service?.corpToken}`;
   }
@@ -100,52 +101,52 @@ export class SearchService {
     let params: any = {};
     let queryArray: string[] = [];
     if (ids.length > 0) {
-      params.where = `id IN (${ids.toString()})`;
-      params.count = `500`;
-      params.fields = `${field},count(id)`;
-      params.groupBy = field;
-      switch (field) {
-        case 'publishedCategory(id,name)':
-          params.orderBy = 'publishedCategory.name';
-          break;
-        case 'address(state)':
-          params.orderBy = 'address.state';
-          break;
-        case 'address(city)':
-          params.orderBy = 'address.city';
-          break;
-        default:
-          params.orderBy = '-count.id';
-          break;
-      }
-      for (let key in params) {
-        queryArray.push(`${key}=${params[key]}`);
-      }
-      let queryString: string = queryArray.join('&');
+    params.where = `id IN (${ids.toString()})`;
+    params.count = `500`;
+    params.fields = `${field},count(id)`;
+    params.groupBy = field;
+    switch (field) {
+      case 'publishedCategory(id,name)':
+        params.orderBy = 'publishedCategory.name';
+        break;
+      case 'address(state)':
+        params.orderBy = 'address.state';
+        break;
+      case 'address(city)':
+        params.orderBy = 'address.city';
+        break;
+      default:
+        params.orderBy = '-count.id';
+        break;
+    }
+    for (let key in params) {
+      queryArray.push(`${key}=${params[key]}`);
+    }
+    let queryString: string = queryArray.join('&');
 
       return this.http.get(`${this.baseUrl}/query/JobBoardPost?${queryString}`); // tslint:disable-line
     } else {
-      return of({ count: 0, start: 0, data: [] });
+      return of({count: 0, start: 0, data: []});
     }
   }
 
   private formatAdditionalCriteria(isSearch: boolean): string {
-    let field: string = SettingsService.settings.additionalJobCriteria.field;
+    let field: string =  SettingsService.settings.additionalJobCriteria.field;
     let values: string[] = SettingsService.settings.additionalJobCriteria.values;
     let query: string = '';
-    let delimiter: '"' | "'" = isSearch ? '"' : "'";
+    let delimiter: '"' | '\'' = isSearch ? '"' : '\'';
     let equals: ':' | '=' = isSearch ? ':' : '=';
 
     if (field && values.length > 0 && field !== '[ FILTER FIELD HERE ]' && values[0] !== '[ FILTER VALUE HERE ]') {
-      for (let i: number = 0; i < values.length; i++) {
-        if (i > 0) {
-          query += ` OR `;
-        } else {
-          query += ' AND (';
+        for (let i: number = 0; i < values.length; i++) {
+            if (i > 0) {
+                query += ` OR `;
+            } else {
+                query += ' AND (';
+            }
+            query += `${field}${equals}${delimiter}${values[i]}${delimiter}`;
         }
-        query += `${field}${equals}${delimiter}${values[i]}${delimiter}`;
-      }
-      query += ')';
+        query += ')';
     }
     return query;
   }
@@ -163,6 +164,7 @@ export class SearchService {
       }
     }
 
-    return additionalFilter.replace(/{\?\^\^equals}/g, isSearch ? ':' : '=').replace(/{\?\^\^delimiter}/g, isSearch ? '"' : "'");
+    return additionalFilter.replace(/{\?\^\^equals}/g, isSearch ? ':' : '=').replace(/{\?\^\^delimiter}/g, isSearch ? '"' : '\'');
   }
+
 }

--- a/src/app/services/search/search.service.ts
+++ b/src/app/services/search/search.service.ts
@@ -7,8 +7,7 @@ import { concatMap, map } from 'rxjs/operators';
 
 @Injectable()
 export class SearchService {
-
-  public constructor(private http: HttpClient, public settings: SettingsService) { }
+  public constructor(private http: HttpClient, public settings: SettingsService) {}
 
   get baseUrl(): string {
     let service: IServiceSettings = SettingsService.settings?.service;
@@ -38,7 +37,7 @@ export class SearchService {
     return this.http.get(`${this.baseUrl}/query/JobBoardPost?where=(id=${id})&fields=${SettingsService.settings?.service?.fields}`);
   }
 
-  public getJobIds(filter: any, ignoreFields: string[]): Observable<any[]> {
+  public getCurrentJobIds(filter: any, ignoreFields: string[]): Observable<any[]> {
     const queryString: string = this.getQueryString(filter, ignoreFields);
 
     return this.getJobRecords(queryString).pipe(
@@ -62,15 +61,13 @@ export class SearchService {
                 // Return the accumulated records when done
                 return of(records);
               }
-            })
+            }),
           );
-        }
+        };
 
         // Start fetching more records recursively
-        return fetchMoreRecords(currentCount).pipe(
-          map(() => records)
-        );
-      })
+        return fetchMoreRecords(currentCount).pipe(map(() => records));
+      }),
     );
   }
 
@@ -97,26 +94,6 @@ export class SearchService {
   private getJobRecords(queryString: string, start: number = 0): Observable<any> {
     // Fetch job records from the API with the specified query and start offset
     return this.http.get(`${this.baseUrl}/search/JobOrder?start=${start}&${queryString}`);
-  }
-
-
-
-  public getCurrentJobIds(filter: any, ignoreFields: string[], start: number = 0): Observable<any> {
-    let queryArray: string[] = [];
-    let params: any = {};
-
-    params.query = `(isOpen:1) AND (isDeleted:0)${this.formatAdditionalCriteria(true)}${this.formatFilter(filter, true, ignoreFields)}`;
-    params.count = `500`;
-    params.fields = 'id';
-    params.sort = 'id';
-    params.start = start;
-
-    for (let key in params) {
-      queryArray.push(`${key}=${params[key]}`);
-    }
-    let queryString: string = queryArray.join('&');
-
-    return this.http.get(`${this.baseUrl}/search/JobOrder?${queryString}`);
   }
 
   public getAvailableFilterOptions(ids: number[], field: string): Observable<any> {
@@ -156,7 +133,7 @@ export class SearchService {
     let field: string = SettingsService.settings.additionalJobCriteria.field;
     let values: string[] = SettingsService.settings.additionalJobCriteria.values;
     let query: string = '';
-    let delimiter: '"' | '\'' = isSearch ? '"' : '\'';
+    let delimiter: '"' | "'" = isSearch ? '"' : "'";
     let equals: ':' | '=' = isSearch ? ':' : '=';
 
     if (field && values.length > 0 && field !== '[ FILTER FIELD HERE ]' && values[0] !== '[ FILTER VALUE HERE ]') {
@@ -186,7 +163,6 @@ export class SearchService {
       }
     }
 
-    return additionalFilter.replace(/{\?\^\^equals}/g, isSearch ? ':' : '=').replace(/{\?\^\^delimiter}/g, isSearch ? '"' : '\'');
+    return additionalFilter.replace(/{\?\^\^equals}/g, isSearch ? ':' : '=').replace(/{\?\^\^delimiter}/g, isSearch ? '"' : "'");
   }
-
 }

--- a/src/app/sidebar/sidebar-filter/sidebar-filter.component.ts
+++ b/src/app/sidebar/sidebar-filter/sidebar-filter.component.ts
@@ -45,7 +45,6 @@ export class SidebarFilterComponent implements OnChanges {
   }
 
   private handleJobIdsOnSuccess(res: any): void {
-    res = res.slice(0, 500);
     let resultIds: number[] = res.map((result: any) => { return result.id; });
     this.service.getAvailableFilterOptions(resultIds, this.field).subscribe(this.setFieldOptionsOnSuccess.bind(this));
 

--- a/src/app/sidebar/sidebar-filter/sidebar-filter.component.ts
+++ b/src/app/sidebar/sidebar-filter/sidebar-filter.component.ts
@@ -41,11 +41,12 @@ export class SidebarFilterComponent implements OnChanges {
 
   private getFilterOptions(): void {
     this.loading = true;
-    this.service.getCurrentJobIds(this.filter, [this.fieldName]).subscribe(this.handleJobIdsOnSuccess.bind(this));
+    this.service.getJobIds(this.filter, [this.fieldName]).subscribe(this.handleJobIdsOnSuccess.bind(this));
   }
 
   private handleJobIdsOnSuccess(res: any): void {
-    let resultIds: number[] = res.data.map((result: any) => { return result.id; });
+    res = res.slice(0, 500);
+    let resultIds: number[] = res.map((result: any) => { return result.id; });
     this.service.getAvailableFilterOptions(resultIds, this.field).subscribe(this.setFieldOptionsOnSuccess.bind(this));
 
   }
@@ -66,7 +67,7 @@ export class SidebarFilterComponent implements OnChanges {
           let values: string[] = [];
           this.lastSetValue = API.getActiveValue();
           if (API.getActiveValue()) {
-            values = API.getActiveValue().map((value: string ) => {
+            values = API.getActiveValue().map((value: string) => {
               return `address.city{?^^equals}{?^^delimiter}${value}{?^^delimiter}`;
             });
           }
@@ -86,7 +87,7 @@ export class SidebarFilterComponent implements OnChanges {
           let values: string[] = [];
           this.lastSetValue = API.getActiveValue();
           if (API.getActiveValue()) {
-            values = API.getActiveValue().map((value: string ) => {
+            values = API.getActiveValue().map((value: string) => {
               return `address.state{?^^equals}{?^^delimiter}${value}{?^^delimiter}`;
             });
           }
@@ -95,22 +96,22 @@ export class SidebarFilterComponent implements OnChanges {
         break;
       case 'publishedCategory(id,name)':
         this.options = res.data
-        .filter((unfilteredResult: ICategoryListResponse) => {
-          return !!unfilteredResult.publishedCategory;
-        })
-        .map((result: ICategoryListResponse) => {
-          return {
-            value: result.publishedCategory.id,
-            label: `${result.publishedCategory.name} (${result.idCount})`,
-          };
-        });
+          .filter((unfilteredResult: ICategoryListResponse) => {
+            return !!unfilteredResult.publishedCategory;
+          })
+          .map((result: ICategoryListResponse) => {
+            return {
+              value: result.publishedCategory.id,
+              label: `${result.publishedCategory.name} (${result.idCount})`,
+            };
+          });
         interaction = (API: FieldInteractionApi) => {
           let values: string[] = [];
           this.lastSetValue = API.getActiveValue();
           if (API.getActiveValue()) {
-          values = API.getActiveValue().map((value: number) => {
-            return `publishedCategory.id{?^^equals}${value}`;
-          });
+            values = API.getActiveValue().map((value: number) => {
+              return `publishedCategory.id{?^^equals}${value}`;
+            });
           }
           this.checkboxFilter.emit(values);
         };
@@ -122,9 +123,9 @@ export class SidebarFilterComponent implements OnChanges {
     this.control = new CheckListControl({
       key: 'checklist',
       options: this.options,
-      interactions: [{event: 'change', script: interaction.bind(this), invokeOnInit: false}],
+      interactions: [{ event: 'change', script: interaction.bind(this), invokeOnInit: false }],
     });
-    this.formUtils.setInitialValues([this.control], {'checklist': this.lastSetValue});
+    this.formUtils.setInitialValues([this.control], { 'checklist': this.lastSetValue });
     this.form = this.formUtils.toFormGroup([this.control]);
     this.loading = false;
   }

--- a/src/app/sidebar/sidebar-filter/sidebar-filter.component.ts
+++ b/src/app/sidebar/sidebar-filter/sidebar-filter.component.ts
@@ -21,7 +21,7 @@ export class SidebarFilterComponent implements OnChanges {
   public options: any[];
   public fieldName: string;
 
-  constructor(private service: SearchService, private formUtils: FormUtils) { }
+  constructor(private service: SearchService, private formUtils: FormUtils) {}
 
   public ngOnChanges(changes: SimpleChanges): void {
     switch (this.field) {
@@ -41,27 +41,30 @@ export class SidebarFilterComponent implements OnChanges {
 
   private getFilterOptions(): void {
     this.loading = true;
-    this.service.getJobIds(this.filter, [this.fieldName]).subscribe(this.handleJobIdsOnSuccess.bind(this));
+    this.service.getCurrentJobIds(this.filter, [this.fieldName]).subscribe(this.handleJobIdsOnSuccess.bind(this));
   }
 
   private handleJobIdsOnSuccess(res: any): void {
-    let resultIds: number[] = res.map((result: any) => { return result.id; });
+    let resultIds: number[] = res.map((result: any) => {
+      return result.id;
+    });
     this.service.getAvailableFilterOptions(resultIds, this.field).subscribe(this.setFieldOptionsOnSuccess.bind(this));
-
   }
 
   private setFieldOptionsOnSuccess(res: any): void {
     let interaction: Function;
     switch (this.field) {
       case 'address(city)':
-        this.options = res.data.map((result: IAddressListResponse) => {
-          return {
-            value: result.address.city,
-            label: `${result.address.city} (${result.idCount})`,
-          };
-        }).filter((item: any) => {
-          return item.value;
-        });
+        this.options = res.data
+          .map((result: IAddressListResponse) => {
+            return {
+              value: result.address.city,
+              label: `${result.address.city} (${result.idCount})`,
+            };
+          })
+          .filter((item: any) => {
+            return item.value;
+          });
         interaction = (API: FieldInteractionApi) => {
           let values: string[] = [];
           this.lastSetValue = API.getActiveValue();
@@ -74,14 +77,16 @@ export class SidebarFilterComponent implements OnChanges {
         };
         break;
       case 'address(state)':
-        this.options = res.data.map((result: IAddressListResponse) => {
-          return {
-            value: result.address.state,
-            label: `${result.address.state} (${result.idCount})`,
-          };
-        }).filter((item: any) => {
-          return item.value;
-        });
+        this.options = res.data
+          .map((result: IAddressListResponse) => {
+            return {
+              value: result.address.state,
+              label: `${result.address.state} (${result.idCount})`,
+            };
+          })
+          .filter((item: any) => {
+            return item.value;
+          });
         interaction = (API: FieldInteractionApi) => {
           let values: string[] = [];
           this.lastSetValue = API.getActiveValue();
@@ -124,9 +129,8 @@ export class SidebarFilterComponent implements OnChanges {
       options: this.options,
       interactions: [{ event: 'change', script: interaction.bind(this), invokeOnInit: false }],
     });
-    this.formUtils.setInitialValues([this.control], { 'checklist': this.lastSetValue });
+    this.formUtils.setInitialValues([this.control], { checklist: this.lastSetValue });
     this.form = this.formUtils.toFormGroup([this.control]);
     this.loading = false;
   }
-
 }

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -37,7 +37,7 @@ export class SidebarComponent {
     !SettingsService.isServer;
   public availableLocales: IAdditionalLanguageOption[] =
     SettingsService.settings?.languageDropdownOptions?.choices || [];
-  constructor(private searchService: SearchService, private router: Router) {}
+  constructor(private searchService: SearchService, private router: Router) { }
 
   public searchOnDelay(): void {
     const keywordSearchFields: string[] =
@@ -53,9 +53,8 @@ export class SidebarComponent {
           if (index > 0) {
             searchString += ' OR ';
           }
-          searchString += `${field}{?^^equals}${
-            this.keyword.trim() ? this.keyword.trim() + '*' : ''
-          }`;
+          searchString += `${field}{?^^equals}${this.keyword.trim() ? this.keyword.trim() + '*' : ''
+            }`;
         });
       }
       delete this.filter['ids'];
@@ -65,7 +64,7 @@ export class SidebarComponent {
         delete this.filter['keyword'];
       }
       this.searchService
-        .getCurrentJobIds(this.filter, [])
+        .getJobIds(this.filter, [])
         .subscribe(this.handleJobIdsOnSuccess.bind(this));
     }, 250);
   }
@@ -101,7 +100,7 @@ export class SidebarComponent {
   }
 
   private handleJobIdsOnSuccess(res: any): void {
-    let resultIds: string[] = res.data.map((result: any) => {
+    let resultIds: string[] = res.map((result: any) => {
       return `id{?^^equals}${result.id}`;
     });
     if (resultIds.length === 0) {

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -1,4 +1,10 @@
-import { Component, Output, EventEmitter, HostBinding, Input } from '@angular/core';
+import {
+  Component,
+  Output,
+  EventEmitter,
+  HostBinding,
+  Input,
+} from '@angular/core';
 import { SettingsService } from '../services/settings/settings.service';
 import { NovoFormGroup } from 'novo-elements';
 import { SearchService } from '../services/search/search.service';
@@ -24,13 +30,18 @@ export class SidebarComponent {
   public timeout: any;
   public loading: boolean = false;
   public filter: object = {};
-  public showPrivacyPolicy: boolean = SettingsService.settings.privacyConsent.sidebarLink;
-  public languageDropdownEnabled = SettingsService.settings.languageDropdownOptions?.enabled && !SettingsService.isServer;
-  public availableLocales: IAdditionalLanguageOption[] = SettingsService.settings?.languageDropdownOptions?.choices || [];
+  public showPrivacyPolicy: boolean =
+    SettingsService.settings.privacyConsent.sidebarLink;
+  public languageDropdownEnabled =
+    SettingsService.settings.languageDropdownOptions?.enabled &&
+    !SettingsService.isServer;
+  public availableLocales: IAdditionalLanguageOption[] =
+    SettingsService.settings?.languageDropdownOptions?.choices || [];
   constructor(private searchService: SearchService, private router: Router) {}
 
   public searchOnDelay(): void {
-    const keywordSearchFields: string[] = SettingsService.settings.service.keywordSearchFields;
+    const keywordSearchFields: string[] =
+      SettingsService.settings.service.keywordSearchFields;
     if (this.timeout) {
       clearTimeout(this.timeout);
     }
@@ -42,7 +53,9 @@ export class SidebarComponent {
           if (index > 0) {
             searchString += ' OR ';
           }
-          searchString += `${field}{?^^equals}${this.keyword.trim() ? this.keyword.trim() + '*' : ''}`;
+          searchString += `${field}{?^^equals}${
+            this.keyword.trim() ? this.keyword.trim() + '*' : ''
+          }`;
         });
       }
       delete this.filter['ids'];
@@ -51,7 +64,9 @@ export class SidebarComponent {
       } else {
         delete this.filter['keyword'];
       }
-      this.searchService.getCurrentJobIds(this.filter, []).subscribe(this.handleJobIdsOnSuccess.bind(this));
+      this.searchService
+        .getCurrentJobIds(this.filter, [])
+        .subscribe(this.handleJobIdsOnSuccess.bind(this));
     }, 250);
   }
 
@@ -74,7 +89,8 @@ export class SidebarComponent {
   }
 
   public viewPrivacyPolicy(): void {
-    const url: string = SettingsService.settings.privacyConsent.privacyPolicyUrl;
+    const url: string =
+      SettingsService.settings.privacyConsent.privacyPolicyUrl;
     if (url === '/privacy') {
       this.router.navigate([url]);
     } else {

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  Output,
-  EventEmitter,
-  HostBinding,
-  Input,
-} from '@angular/core';
+import { Component, Output, EventEmitter, HostBinding, Input } from '@angular/core';
 import { SettingsService } from '../services/settings/settings.service';
 import { NovoFormGroup } from 'novo-elements';
 import { SearchService } from '../services/search/search.service';
@@ -30,18 +24,13 @@ export class SidebarComponent {
   public timeout: any;
   public loading: boolean = false;
   public filter: object = {};
-  public showPrivacyPolicy: boolean =
-    SettingsService.settings.privacyConsent.sidebarLink;
-  public languageDropdownEnabled =
-    SettingsService.settings.languageDropdownOptions?.enabled &&
-    !SettingsService.isServer;
-  public availableLocales: IAdditionalLanguageOption[] =
-    SettingsService.settings?.languageDropdownOptions?.choices || [];
-  constructor(private searchService: SearchService, private router: Router) { }
+  public showPrivacyPolicy: boolean = SettingsService.settings.privacyConsent.sidebarLink;
+  public languageDropdownEnabled = SettingsService.settings.languageDropdownOptions?.enabled && !SettingsService.isServer;
+  public availableLocales: IAdditionalLanguageOption[] = SettingsService.settings?.languageDropdownOptions?.choices || [];
+  constructor(private searchService: SearchService, private router: Router) {}
 
   public searchOnDelay(): void {
-    const keywordSearchFields: string[] =
-      SettingsService.settings.service.keywordSearchFields;
+    const keywordSearchFields: string[] = SettingsService.settings.service.keywordSearchFields;
     if (this.timeout) {
       clearTimeout(this.timeout);
     }
@@ -53,8 +42,7 @@ export class SidebarComponent {
           if (index > 0) {
             searchString += ' OR ';
           }
-          searchString += `${field}{?^^equals}${this.keyword.trim() ? this.keyword.trim() + '*' : ''
-            }`;
+          searchString += `${field}{?^^equals}${this.keyword.trim() ? this.keyword.trim() + '*' : ''}`;
         });
       }
       delete this.filter['ids'];
@@ -63,16 +51,11 @@ export class SidebarComponent {
       } else {
         delete this.filter['keyword'];
       }
-      this.searchService
-        .getJobIds(this.filter, [])
-        .subscribe(this.handleJobIdsOnSuccess.bind(this));
+      this.searchService.getCurrentJobIds(this.filter, []).subscribe(this.handleJobIdsOnSuccess.bind(this));
     }, 250);
   }
 
-  public updateFilter(
-    field: string,
-    httpFormatedFilter: string | string[],
-  ): void {
+  public updateFilter(field: string, httpFormatedFilter: string | string[]): void {
     delete this.filter['keyword'];
     if (Array.isArray(httpFormatedFilter) && httpFormatedFilter.length === 500) {
       this.filter = {};
@@ -91,8 +74,7 @@ export class SidebarComponent {
   }
 
   public viewPrivacyPolicy(): void {
-    const url: string =
-      SettingsService.settings.privacyConsent.privacyPolicyUrl;
+    const url: string = SettingsService.settings.privacyConsent.privacyPolicyUrl;
     if (url === '/privacy') {
       this.router.navigate([url]);
     } else {
@@ -105,7 +87,7 @@ export class SidebarComponent {
   }
 
   private handleJobIdsOnSuccess(res: any): void {
-    res = res.slice(0, 500)
+    res = res.slice(0, 500);
     let resultIds: string[] = res.map((result: any) => {
       return `id{?^^equals}${result.id}`;
     });

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -74,11 +74,16 @@ export class SidebarComponent {
     httpFormatedFilter: string | string[],
   ): void {
     delete this.filter['keyword'];
-    this.filter[field] = httpFormatedFilter;
-    let filter: object = {};
-    Object.assign(filter, this.filter);
-    this.filter = filter; // triggering angular change detection
-    this.newFilter.emit(this.filter);
+    if (Array.isArray(httpFormatedFilter) && httpFormatedFilter.length === 500) {
+      this.filter = {};
+      this.newFilter.emit(this.filter);
+    } else {
+      this.filter[field] = httpFormatedFilter;
+      let filter: object = {};
+      Object.assign(filter, this.filter);
+      this.filter = filter; // triggering angular change detection
+      this.newFilter.emit(this.filter);
+    }
   }
 
   public hideSidebar(): void {
@@ -100,6 +105,7 @@ export class SidebarComponent {
   }
 
   private handleJobIdsOnSuccess(res: any): void {
+    res = res.slice(0, 500)
     let resultIds: string[] = res.map((result: any) => {
       return `id{?^^equals}${result.id}`;
     });


### PR DESCRIPTION
For filter options with over 500+ records, the totals in the filter are wrong. This PR should resolve issue #525 

## Additions / Removals

- Pull more records in the getCurrentJobIds function. Return records.
- In the sidebar component, if total is greater than 500+ records, there will be a bad request due to overload of data. To fix this, I sliced initial 500 records. If the user removes the search or filter results are more than 500+ records, the filter will be reset. 
- In the sidebar filter component, I changed "res.data.map" to "res.map" as I have changed getCurrentJobIds to return all records. 

## Testing

- Using #525 corp, I created a screenshot of the desired output. 

## Screenshots

![image](https://github.com/bullhorn/career-portal/assets/95382086/e09c79a2-b6a2-422e-95c9-9ae1be3474e3)
![image](https://github.com/bullhorn/career-portal/assets/95382086/b697e04f-1643-4b4a-9bfb-7941677dd074)
![image](https://github.com/bullhorn/career-portal/assets/95382086/88fbad76-c4a5-4206-9c70-d1105995f5b2)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
