### PR TITLE
Fix overlapping chips within mobile iframe

### DIFF
--- a/src/app/components/info-chips/info-chips.component.scss
+++ b/src/app/components/info-chips/info-chips.component.scss
@@ -4,7 +4,10 @@
     margin: 5px;
     background-color: #f4f4f4;
     border-radius: 8px;
-    align-self: center;
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
+    box-sizing: border-box;
     i {
       font-size: 1em;
     }


### PR DESCRIPTION
INSERT SHORT DESCRIPTION EXPLAINING THE HIGH-LEVEL REASON FOR THE NEW PULL REQUEST HERE.

Amended Info Chip CSS code to prevent overlapping chips on mobiles. 

-

## Testing
Tested changes on both mobile and desktop. Desktop experience is unaffected by changes, mobile experience is vastly improved.
-

## Screenshots
**Before:**
<img width="720" height="1560" alt="image" src="https://github.com/user-attachments/assets/c9e66173-f843-4a0f-8eaf-589fc36cd7df" />
<img width="720" height="1560" alt="image" src="https://github.com/user-attachments/assets/e71053ae-0227-41f9-9b81-2454d6dc9afc" />

**After:**
<img width="475" height="616" alt="image" src="https://github.com/user-attachments/assets/17af310b-35e8-49cd-b07a-149b04bb8e95" />
<img width="854" height="798" alt="image" src="https://github.com/user-attachments/assets/ab76b841-5c8d-4f85-9272-e1f23d7161c7" />

## Notes

-

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
