### PR TITLE
ci: modernize workflows, run on PRs, and automate release asset publishing 

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,39 +1,36 @@
-on: push
+on:
+  push:
+  pull_request:
+
 name: Build
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16.20.2]
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache node modules
-        uses: actions/cache@v4
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Install Dependencies
-        run: sudo apt-get install expect libnotify-bin
+          node-version-file: 'package.json'
+          cache: 'npm'
+
       - name: Install
         run: npm ci
+
       - name: Lint
         run: npm run lint
+
       - name: Build SSR
         run: npm run build:ssr
+
       - name: Build Static
         run: |
           node version.js
           npm run build:static
-      - uses: actions/upload-artifact@master
+
+      - uses: actions/upload-artifact@v7
         with:
           name: build-artifact
           path: dist/career-portal/browser
-
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,64 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version from tag
+        id: tag
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Tag does not look like a valid semver version: $version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Validate package.json version matches tag
+        env:
+          TAG_VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          pkg_version=$(node -p "require('./package.json').version")
+          if [ "$pkg_version" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($pkg_version) does not match tag (v$TAG_VERSION)"
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: |
+          node version.js
+          npm run build:static
+
+      - name: Create release zip
+        env:
+          TAG_VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          cd dist/career-portal/browser
+          zip -r "$GITHUB_WORKSPACE/career-portal-v${TAG_VERSION}.zip" .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+          files: career-portal-v${{ steps.tag.outputs.version }}.zip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,26 +1,46 @@
 on:
   push:
+  pull_request:
   schedule:
-    - cron:  '30 5,17 * * *'
+    - cron: '30 5,17 * * *'
+
 name: Test
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16.20.2]
     env:
       DBUS_SESSION_BUS_ADDRESS: /dev/null
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: 'package.json'
+          cache: 'npm'
+
       - name: Run tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v7
         with:
           start: npm run serve
           wait-on: 'http://localhost:4200'
           wait-on-timeout: 120
+
+      - name: Upload Cypress screenshots
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Cypress videos
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cypress-videos
+          path: cypress/videos
+          if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Change to the Career Portal directory:
 cd career-portal
 ```
 
+The required Node version is declared in `engines.node` in `package.json`. To pick it up automatically:
+
+- **nvm**: `nvm use --engines` (install with `nvm install --engines` if the version is missing)
+- **fnm**: `fnm use`
+
 Install build tools and dev dependencies:
 
 ```

--- a/version.js
+++ b/version.js
@@ -2,8 +2,8 @@
 const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
-const JenkinsBuildNumber = process.argv['GITHUB_RUN_NUMBER'] || 'UNKNOWN';
-const CommitHash = process.argv['GITHUB_SHA'] || 'UNKNOWN';
+const buildNumber = process.env.GITHUB_RUN_NUMBER || 'UNKNOWN';
+const commitHash = process.env.GITHUB_SHA || 'UNKNOWN';
 const now = new Date();
 
 let data = `
@@ -17,8 +17,8 @@ _________                                           __________                  
 Date: ${now.toUTCString()}
 Career Portal Version: ${require('./package.json').version}
 Build Information:
-  Build#: ${JenkinsBuildNumber}
-  Commit: ${CommitHash}
+  Build#: ${buildNumber}
+  Commit: ${commitHash}
 Dependency Information:
   NovoElements: ${require('./node_modules/novo-elements/package.json').version}
 `;


### PR DESCRIPTION
Modernizes the GitHub Actions workflows, makes them run on pull requests, and adds a release pipeline that automatically attaches a build artifact to GitHub Releases.

## Additions / Removals

- **Upgraded pinned actions** in `main.yaml` and `test.yaml`: `actions/checkout@v2` -> `@v6`, `actions/setup-node@v1` -> `@v6`, `actions/upload-artifact@master` -> `@v7`, `cypress-io/github-action@v2` -> `@v7`.
- **Single source of Node version**: replaced the hardcoded Node matrix with `node-version-file: 'package.json'`.
- Replaced the bespoke `actions/cache` step with the built-in `cache: 'npm'` on `setup-node`.
- Removed the `sudo apt-get install expect libnotify-bin` step - no longer needed with modern Cypress images.
- Test workflow now uploads Cypress screenshots and videos as artifacts on failure (7-day retention) for easier CI triage.
- **Run CI on pull requests**: both `main.yaml` and `test.yaml` now trigger on `pull_request` in addition to `push`. Previously these only ran on push, which meant a feature branch's failing build wouldn't block the PR being merged. With `pull_request` triggers, branch protection rules can now require green checks before merge.
- **New `release.yaml` workflow** triggered by pushing a `v*` tag. It validates the tag is semver and matches `package.json`'s `version`, runs `npm ci`, lint, and `build:static`, zips `dist/career-portal/browser` into `career-portal-v<version>.zip`, and creates a GitHub Release with auto-generated release notes and the zip attached. This addresses a recurring issue where release assets were missing from several recent releases - the build-and-attach step is now part of the tag workflow rather than a manual post-release action.
- Fixed `version.js` reading build metadata from `process.argv` instead of `process.env` - `Build#` and `Commit` were both always `UNKNOWN` before.
- Added nvm/fnm `engines` usage tips to `README.md`.

## Testing

- `test.yaml` and `main.yaml` run on PRs against the fork and pass.
- `release.yaml` triggered by pushing a `v*` tag produces a GitHub Release with the static zip attached.
https://github.com/ChrisLane/career-portal/releases/tag/v3.7.1

## Screenshots


## Notes

- The [advanced install docs](https://bullhorn.github.io/career-portal/advanced-install.html) document a `career-portal-v<version>-dynamic.zip` asset (the SSR / dynamic build) alongside the static zip. This asset has not been published on any recent release and is **not** addressed by this PR - the new release workflow only produces the static zip (`career-portal-v<version>.zip`). Adding the dynamic build output to the release workflow should be tracked as a separate piece of work so it can be scoped and reviewed on its own.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
