### PR TITLE
refactor(trust-snippet): use career-portal vendor snippet

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,18 +8,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <script src="https://trust-snippet.bullhornstaffing.com/trust-snippet.min.js"></script>
-  <script>
-    document.addEventListener("DOMContentLoaded", async function() {
-      try {
-        const raw = await fetch('./app.json')
-        const appData = await raw.json();
-        Trust.start({corpToken: appData.service.corpToken});
-      } catch(err) {
-        console.error("[TrustSnippet] Failed to start session:", err);
-      }
-    });
-  </script>
+  <script src="https://trust-snippet.bullhornstaffing.com/trust-snippet-career-portal.min.js"></script>
 </head>
 <body>
   <app-root><novo-loading style="position: absolute; margin: auto; top: 0; left: 0; right: 0; bottom: 0;display: flex;justify-content: center;align-items: center;">


### PR DESCRIPTION
## Summary

BA-10664

Switch `src/index.html` to load the career-portal-specific trust snippet (`trust-snippet-career-portal.min.js`), which sets `CAREER_PORTAL_AUTO_START=true` internally. This removes the inline bootstrap script that fetched `app.json` and called `Trust.start()` manually. The change also aligns this app with the manual integration path we recommend to clients where a full career-portal upgrade is not feasible.

## Additions / Removals

- Switch the trust snippet in `src/index.html` to the career-portal-specific build (`trust-snippet-career-portal.min.js`).
- Remove the inline bootstrap script that fetched `app.json` and called `Trust.start({ corpToken })` manually - the new snippet auto-starts via `CAREER_PORTAL_AUTO_START=true`.

## Testing

- Loaded the app locally and confirmed the trust session initialises without the inline bootstrap.
- Verified no console errors from the snippet and that `Trust` is started against the correct `corpToken` from `app.json`.

## Screenshots


## Notes

- Aligns this repo with the manual integration path documented for clients who cannot do a full career-portal upgrade.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices

