### PR TITLE
fix(csp): allow trust-fp and worker blobs for trust-snippet

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -66,7 +66,8 @@ export function app(): express.Express {
       'Content-Security-Policy',
       [
         "default-src 'self'",
-        "script-src 'self' 'unsafe-inline' https://trust-snippet.bullhornstaffing.com https://www.google-analytics.com",
+        "script-src 'self' 'unsafe-inline' https://trust-snippet.bullhornstaffing.com https://trust-fp.bullhornstaffing.com https://www.google-analytics.com",
+        "worker-src 'self' blob:",
         "style-src 'self' 'unsafe-inline'",
         "img-src 'self' data: https:",
         "font-src 'self' data:",


### PR DESCRIPTION
The trust-snippet's resource loading was being blocked by the
Content-Security-Policy added in 2fc5f20 (SOLEN-2969): the snippet
loads an additional script from `trust-fp.bullhornstaffing.com`, 
and that script spawns a WebWorker from a `blob:` URL. Both were
silently rejected, so data collection failed with an error in the
browser console.
This permits both so the trust flow works end-to-end.

## Additions / Removals

- Allow `https://trust-fp.bullhornstaffing.com` in `script-src`.
- Add `worker-src 'self' blob:` to permit blob worker.

## Testing

- Loaded the app locally and confirmed no CSP violations are reported in the console for the trust-snippet.
- Verified `[TrustSnippet] Failed to get FP result` is no longer emitted and data collection completes successfully.

## Screenshots


## Notes


## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
