### PR TITLE
test(cypress): fix flakey job category assertion timing

### DIFF
--- a/cypress/integration/spec.ts
+++ b/cypress/integration/spec.ts
@@ -35,12 +35,13 @@ describe('Job List', () => {
         cy.get(`[data-automation-id="${CSS.escape(automationId)}"]`).first().click();
         cy.wait('@getCategories', {timeout: 30000});
         cy.wait('@getJobs', {timeout: 30000});
-        cy.get('novo-list>div.job-card').each(($jobEl, jobIndex, $jobList) => {
-          const categoryCountRegex = /\(([^)]+)\)/;
-          const count = parseInt(categoryCountRegex.exec(automationId)[1]);
-          expect($jobList.length, 'The correct number of results for the specified category is not showing').equals(count);
-          cy.get('span.category').should('include.text', automationId.replace(` (${count})`, ''));
-        });
+        const categoryCountRegex = /\(([^)]+)\)/;
+        const count = parseInt(categoryCountRegex.exec(automationId)[1]);
+        cy.get('novo-list>div.job-card', {timeout: 30000})
+          .should('have.length', count)
+          .each(($jobEl) => {
+            cy.wrap($jobEl).find('span.category').should('include.text', automationId.replace(` (${count})`, ''));
+          });
         cy.get('.bhi-checkbox-filled').click();
         cy.wait('@getCategories', {timeout: 30000});
         cy.wait(1000);


### PR DESCRIPTION
Replace per-element iteration with a length assertion before checking each job card's category, so Cypress retries until the rendered list matches the expected count instead of asserting against a partially-rendered list.

## Additions / Removals

- Refactored the job category test in `cypress/integration/spec.ts` to assert `novo-list>div.job-card` has the expected length (with timeout) before iterating, then scope the category text check via `cy.wrap($jobEl).find('span.category')`.
- Removed the `$jobList.length` assertion inside `.each()` that previously raced against list rendering.

## Testing

- Pushed the changes and confirmed that the test still passes :crossed_fingers: for consistency

## Screenshots


## Notes

- Root cause: the previous `.each()` block parsed the expected count from the automation id on every iteration and asserted list length mid-render, which intermittently failed before the DOM had settled. Cypress' built-in retry on `should('have.length', ...)` now waits for the list to stabilise.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/career-portal/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
